### PR TITLE
「Content Length」を「コンテンツサイズ」に変えてみました

### DIFF
--- a/documentation/2.0.2/manual/javaGuide/main/cache/JavaCache.md
+++ b/documentation/2.0.2/manual/javaGuide/main/cache/JavaCache.md
@@ -1,4 +1,4 @@
-<!--translated-->
+<!-- translated -->
 <!--
 # The Play cache API
 -->

--- a/documentation/2.0.2/manual/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/2.0.2/manual/javaGuide/main/http/JavaBodyParsers.md
@@ -127,17 +127,17 @@ pulic static Result save() {
 <!--
 ## Max content length
 -->
-## 最大 Content Length
+## 最大コンテンツサイズ
 
 <!--
 Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory. 
 -->
-テキストベースのボディパーサー (**text**, **json**, **xml**, **formUrlEncoded** 等) は全てのコンテンツを一旦メモリにロードする必要があるため、最大 Content Lengthが設定されています。
+テキストベースのボディパーサー (**text**, **json**, **xml**, **formUrlEncoded** 等) は全てのコンテンツを一旦メモリにロードする必要があるため、最大コンテンツサイズが設定されています。
 
 <!--
 There is a default content length (the default is 100KB). 
 -->
-デフォルトでは Content Length は 100KB です。
+デフォルトではコンテンツサイズは 100KB です。
 
 <!--
 > **Tip:** The default content size can be defined in `application.conf`:

--- a/documentation/2.0.2/manual/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/2.0.2/manual/scalaGuide/main/http/ScalaBodyParsers.md
@@ -224,17 +224,17 @@ def save = Action(storeInUserFile) { request =>
 <!--
 ## Max content length
 -->
-## 最大 Content Length
+## 最大コンテンツサイズ
 
 <!--
 Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a maximum content length because they have to load all of the content into memory. 
 -->
-テキストベースのボディパーサー (**text**, **json**, **xml**, **formUrlEncoded** のような。) は全てのコンテンツを一旦メモリにロードする必要があるため、最大 Content Lengthが設定されています。
+テキストベースのボディパーサー (**text**, **json**, **xml**, **formUrlEncoded** のような。) は全てのコンテンツを一旦メモリにロードする必要があるため、最大コンテンツサイズが設定されています。
 
 <!--
 There is a default content length (the default is 100KB), but you can also specify it inline:
 -->
-デフォルトでは Content Length は 100KB ですが、コード中で指定することもできます。
+デフォルトではコンテンツサイズは 100KB ですが、コード中で指定することもできます。
 
 ```scala
 // Accept only 10KB of data.

--- a/documentation/2.0.3/manual/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/2.0.3/manual/scalaGuide/main/http/ScalaBodyParsers.md
@@ -224,17 +224,17 @@ def save = Action(storeInUserFile) { request =>
 <!--
 ## Max content length
 -->
-## 最大 Content Length
+## 最大コンテンツサイズ
 
 <!--
 Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a maximum content length because they have to load all of the content into memory. 
 -->
-テキストベースのボディパーサー (**text**, **json**, **xml**, **formUrlEncoded** のような。) は全てのコンテンツを一旦メモリにロードする必要があるため、最大 Content Lengthが設定されています。
+テキストベースのボディパーサー (**text**, **json**, **xml**, **formUrlEncoded** のような。) は全てのコンテンツを一旦メモリにロードする必要があるため、最大コンテンツサイズが設定されています。
 
 <!--
 There is a default content length (the default is 100KB), but you can also specify it inline:
 -->
-デフォルトでは Content Length は 100KB ですが、コード中で指定することもできます。
+デフォルトではコンテンツサイズは 100KB ですが、コード中で指定することもできます。
 
 ```scala
 // Accept only 10KB of data.


### PR DESCRIPTION
HTTP ヘッダの 「content length」 の訳が英語のままだったのですが、個人的には「コンテンツサイズ」が一般的だと思ったので、変えてみました。
