### PR TITLE
#150 代替設定ファイルの指定

### DIFF
--- a/documentation/2.0.2/manual/detailledTopics/configuration/Configuration.md
+++ b/documentation/2.0.2/manual/detailledTopics/configuration/Configuration.md
@@ -29,7 +29,7 @@ System properties can be used to force a different config source:
 * `config.file` specifies a filesystem path, again it should include the extension, not be a basename
 * `config.url` specifies a URL
 -->
-* `config.resource` はリソースファイルの指定です - application のようなベースネームは指定できません。つまり application ではなく application.conf となります。
+* `config.resource` はリソースファイルの指定です - application のようなベースネームの指定はできません。つまり application ではなく application.conf となります。
 * `config.file` はファイルシステム上のパスの指定です。パスには拡張子を含みます。ベースネームの指定はできません。
 * `config.url` は URL の指定です。
 

--- a/documentation/2.0.2/manual/detailledTopics/configuration/Configuration.md
+++ b/documentation/2.0.2/manual/detailledTopics/configuration/Configuration.md
@@ -29,7 +29,7 @@ System properties can be used to force a different config source:
 * `config.file` specifies a filesystem path, again it should include the extension, not be a basename
 * `config.url` specifies a URL
 -->
-* `config.resource` はリソースファイルの指定です - application のようなベースネームの指定はできません。また、 application.conf 以外を指定します。
+* `config.resource` はリソースファイルの指定です - application のようなベースネームは指定できません。つまり application ではなく application.conf となります。
 * `config.file` はファイルシステム上のパスの指定です。パスには拡張子を含みます。ベースネームの指定はできません。
 * `config.url` は URL の指定です。
 


### PR DESCRIPTION
原文:
config.resource specifies a resource name - not a basename, i.e. application and not application.conf

原文の意図としては単純に「拡張子が入ります」という意味で、「application.conf を指定しない」という事は書かれていないように読めました。

一応 start スクリプトを実行して確認したところ、拡張子は必要、application.conf の指定は可能 (もちろん普通は指定する必要はありませんが…) でした。

ただし、原文を見ると逆の事を書いているようにも見えます。…正直な所、判断が難しい所です。
