### PR TITLE
本家ドキュメントの修正を反映(Future#asPromise)

### DIFF
--- a/documentation/2.0.4/manual/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/2.0.4/manual/scalaGuide/main/akka/ScalaAkka.md
@@ -64,9 +64,9 @@ akka.actor.debug.receive = on
 ## Akka `Future` から Play `Promise` への変換
 
 <!--
-When you interact asynchronously with an Akka actor we will get `Future` object. You can easily convert it to a Play `Promise` using the implicit conversion provided in `play.libs.Akka._`:
+When you interact asynchronously with an Akka actor we will get `Future` object. You can easily convert it to a Play `Promise` using the implicit conversion provided in `play.api.libs.concurrent._`:
 -->
-Akka アクターと非同期的にやり取りをすると、 `Future` オブジェクトが返ってきます。`play.libs.Akka._` に用意されている implicit conversion を利用すると、この `Future` を Play の `Promise` オブジェクトに簡単に変換することができます。
+Akka アクターと非同期的にやり取りをすると、 `Future` オブジェクトが返ってきます。`play.api.libs.concurrent._` に用意されている implicit conversion を利用すると、この `Future` を Play の `Promise` オブジェクトに簡単に変換することができます。
 
 ```scala
 def index = Action {


### PR DESCRIPTION
- Future#asPromise のサポートをするためのパッケージのパスが間違っていました
