### PR TITLE
JSON から OO 構造へ変換する理由の考察の訳の別の解釈 #320

### DIFF
--- a/documentation/2.1.0/manual/scalaGuide/main/json/ScalaJsonTransformers.md
+++ b/documentation/2.1.0/manual/scalaGuide/main/json/ScalaJsonTransformers.md
@@ -21,7 +21,7 @@
 <!-- - for a good reason : **OO structures are "language-native"** and allows **manipulating data with respect to your business logic** in a seamless way while ensuring isolation of business logic from web layers.
 - for a more questionable reason : **ORM frameworks talk to DB only with OO structures** and we have (kind of) convinced ourselves that it was impossible to do else… with the well-known good & bad features of ORMs… (not here to criticize those stuff) -->
 - 妥当な理由 : **オブジェクト指向構造は "プログラミング言語ネイティブ"** であり、ビジネスロジックを web 層から隔離しつつ、自然な方法で **ビジネスロジックに対してデータを操作する** ことができるため
-- より疑わしい理由 : **ORM フレームワークはオブジェクト指向構造のみを通じて DB とやり取りする** ためであり、そして …ORM のよく知られた良い機能や悪い機能を使う場合は… 他のやり方なんて不可能だと自分たちを (ある程度) 納得させているため (ここで ORM を批判しているわけではありません)
+- より疑わしい理由 : **ORM フレームワークはオブジェクト指向構造を通してしか DB とやり取りできない**、他のやり方なんて不可能だ …ORM のよく知られた良い機能や悪い機能と付き合いながらね…と自分たちを (ある程度) 納得させているため (ここで ORM を批判しているわけではありません)
 
 
 <!-- ### <a name="is-default-case">Is OO conversion really the default usecase?</a> -->


### PR DESCRIPTION
原文が若干崩れた書き方に見えます。うまく説明しづらいのですが…

この文は「… with」以前と以降を少し間を置いて語っているイメージなのかな、と思いました。

前半は

> ORM frameworks talk to DB only with OO structures and we have (kind of) convinced ourselves that it was impossible to do else…

で、ORM を使うには OO の構造が必須だししょうがないじゃないか、という主張だと思います。

後半は

> … with the well-known good & bad features of ORMs…

「ORM は色々と問題があるが」…とふてくされているのかな、と。
