### PR TITLE
manual/javaGuide/main/global/JavaGlobal.md

### DIFF
--- a/documentation/2.2.0/manual/javaGuide/main/global/JavaGlobal.md
+++ b/documentation/2.2.0/manual/javaGuide/main/global/JavaGlobal.md
@@ -1,31 +1,65 @@
+<!-- translated -->
+<!--
 # Application global settings
+-->
+# アプリケーションのグローバル設定
 
+<!--
 ## The Global object
+-->
+## Global オブジェクト
 
+<!--
 Defining a `Global` object in your project allows you to handle global settings for your application. This object must be defined in the root package.
+-->
+プロジェクト内に `Global` オブジェクトを定義すると、アプリケーションのグローバル設定を行うことができます。このオブジェクトはルートパッケージに定義される必要があります。
 
 @[global](code/javaguide/global/simple/Global.java)
 
+<!--
 ## Intercepting application start-up and shutdown
+-->
+## アプリケーションの起動や停止をインターセプトする
 
+<!--
 You can override the `onStart` and `onStop` operation to be notified of the corresponding application lifecycle events:
+-->
+`onStart` や `onStop` 操作をオーバーライドすることで、対応するアプリケーションのライフサイクルイベントの通知を受けることができます。
 
 @[global](code/javaguide/global/startstop/Global.java)
 
+<!--
 ## Providing an application error page
+-->
+## アプリケーションのエラーページを提供する
 
+<!--
 When an exception occurs in your application, the `onError` operation will be called. The default is to use the internal framework error page. You can override this:
+-->
+アプリケーションで例外が発生すると、`onError` 操作が呼び出されます。デフォルトでは、フレームワークに用意されている汎用的なエラーページを表示するようになっていますが、これをオーバーライドすることができます。
 
 @[global](code/javaguide/global/onerror/Global.java)
 
+<!--
 ## Handling action not found
+-->
+## 存在しないアクションを扱う
 
+<!--
 If the framework doesn’t find an action method for a request, the `onHandlerNotFound` operation will be called:
+-->
+フレームワークがリクエストに対応するアクションを見つけられなかった場合、`onHandlerNotFound` 操作が呼び出されます。
 
 @[global](code/javaguide/global/notfound/Global.java)
 
+<!--
 The `onBadRequest` operation will be called if a route was found, but it was not possible to bind the request parameters:
+-->
+また、ルートは存在するものの、リクエストパラメータをバインドできなかった場合は、`onBadRequest` 操作が呼び出されます。
 
 @[global](code/javaguide/global/badrequest/Global.java)
 
+<!--
 > **Next:** [[Intercepting requests | JavaInterceptors]]
+-->
+> **次ページ:** [[リクエストのインターセプト | JavaInterceptors]]


### PR DESCRIPTION
- https://github.com/garbagetown/playdocja/blob/2.2.0/documentation/2.2.0/manual/javaGuide/main/global/JavaGlobal.md

```
--- /Users/garbagetown/Desktop/2.1.5/manual/javaGuide/main/global/JavaGlobal.md 2013-09-19 22:53:02.000000000 +0900
+++ /Users/garbagetown/Desktop/2.2.0/manual/javaGuide/main/global/JavaGlobal.md 2013-09-19 10:11:22.000000000 +0900
@@ -4,96 +4,28 @@

 Defining a `Global` object in your project allows you to handle global settings for your application. This object must be defined in the root package.

-'''java
-import play.*;
-
-public class Global extends GlobalSettings {
-
-}
-'''
+@[global](code/javaguide/global/simple/Global.java)

 ## Intercepting application start-up and shutdown

 You can override the `onStart` and `onStop` operation to be notified of the corresponding application lifecycle events:

-'''java
-import play.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public void onStart(Application app) {
-    Logger.info("Application has started");
-  }  
-  
-  @Override
-  public void onStop(Application app) {
-    Logger.info("Application shutdown...");
-  }  
-    
-}
-'''
+@[global](code/javaguide/global/startstop/Global.java)

 ## Providing an application error page

 When an exception occurs in your application, the `onError` operation will be called. The default is to use the internal framework error page. You can override this:

-'''java
-import play.*;
-import play.mvc.*;
-
-import static play.mvc.Results.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public Result onError(RequestHeader request, Throwable t) {
-    return internalServerError(
-      views.html.errorPage(t)
-    );
-  }  
-    
-}
-'''
+@[global](code/javaguide/global/onerror/Global.java)

 ## Handling action not found

 If the framework doesn’t find an action method for a request, the `onHandlerNotFound` operation will be called:

-'''java
-import play.*;
-import play.mvc.*;
-
-import static play.mvc.Results.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public Result onHandlerNotFound(RequestHeader request) {
-    return Results.notFound(
-      views.html.pageNotFound(request.uri())
-    );
-  }  
-    
-}
-'''
+@[global](code/javaguide/global/notfound/Global.java)

 The `onBadRequest` operation will be called if a route was found, but it was not possible to bind the request parameters:

-'''java
-import play.*;
-import play.mvc.*;
-
-import static play.mvc.Results.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public Result onBadRequest(RequestHeader request, String error) {
-    return Results.badRequest("Don't try to hack the URI!");
-  }  
-    
-}
-'''
+@[global](code/javaguide/global/badrequest/Global.java)

 > **Next:** [[Intercepting requests | JavaInterceptors]]

```
