### PR TITLE
manual/javaGuide/main/json/JavaJsonRequests.md

### DIFF
--- a/documentation/2.2.0/manual/javaGuide/main/json/JavaJsonRequests.md
+++ b/documentation/2.2.0/manual/javaGuide/main/json/JavaJsonRequests.md
@@ -1,10 +1,23 @@
+<!-- translated -->
+<!--
 # Handling and serving JSON requests
+-->
+# JSON リクエストとレスポンス
 
+<!--
 ## Handling a JSON request
+-->
+## JSON リクエストの処理
 
+<!--
 A JSON request is an HTTP request using a valid JSON payload as request body. Its `Content-Type` header must specify the `text/json` or `application/json` MIME type.
+-->
+JSON リクエストは JSON データをリクエストボディに含む HTTP リクエストです。JSON リクエストは、`Content-Type` ヘッダに `text/json` か `application/json` という MIME タイプを指定する必要があります。
 
+<!--
 By default an action uses an **any content** body parser, which you can use to retrieve the body as JSON (actually as a Jackson `JsonNode`):
+-->
+アクションは **any content** ボディパーサーをデフォルトで使います。これを利用して、リクエストボディを JSON (具体的には Jackson の `JsonNode`) として取得することができます。
 
 ```java
 import com.fasterxml.jackson.databind.JsonNode;
@@ -25,7 +38,10 @@ public static Result sayHello() {
 }
 ```
 
+<!--
 Of course it’s way better (and simpler) to specify our own `BodyParser` to ask Play to parse the content body directly as JSON:
+-->
+この場合、専用の`BodyParser` を指定することで Play にコンテントボディを直接的に JSON としてパースさせると、記述がシンプル化されてなお良いでしょう。
 
 ```java
 import com.fasterxml.jackson.databind.JsonNode;
@@ -44,9 +60,15 @@ public static Result sayHello() {
 }
 ```
 
+<!--
 > **Note:** This way, a 400 HTTP response will be automatically returned for non JSON requests with Content-type set to application/json. 
+-->
+> **ノート:** この方法では、JSON 以外のリクエストに対しては自動的に HTTP の 400 番のレスポンスが application/json に設定された Content-type と共に返ってきます。
 
+<!--
 You can test it with **cURL** from a command line:
+-->
+このアクションは、コマンドラインから **cURL** を使って以下のようにテストできます。
 
 ```bash
 curl 
@@ -56,7 +78,10 @@ curl
   http://localhost:9000/sayHello
 ```
 
+<!--
 It replies with:
+-->
+レスポンスは以下のようになります。
 
 ```http
 HTTP/1.1 200 OK
@@ -66,9 +91,15 @@ Content-Length: 15
 Hello Guillaume
 ```
 
+<!--
 ## Serving a JSON response
+-->
+## JSON レスポンスの送信
 
+<!--
 In our previous example we handled a JSON request, but replied with a `text/plain` response. Let’s change that to send back a valid JSON HTTP response:
+-->
+前述の例ではリクエストを JSON で受けていましたが、レスポンスは `text/plain` として送信していました。これを、正しい JSON HTTP レスポンスを送り返すように変更してみましょう。
 
 ```java
 import play.libs.Json;
@@ -92,7 +123,10 @@ public static Result sayHello() {
 }
 ```
 
+<!--
 Now it replies with:
+-->
+レスポンスは以下のようになります。
 
 ```http
 HTTP/1.1 200 OK
@@ -102,4 +136,7 @@ Content-Length: 43
 {"status":"OK","message":"Hello Guillaume"}
 ```
 
+<!--
 > **Next:** [[Working with XML | JavaXmlRequests]]
+-->
+> **次ページ:** [[XML | JavaXmlRequests]]


### PR DESCRIPTION
- https://github.com/garbagetown/playdocja/blob/2.2.0/documentation/2.2.0/manual/javaGuide/main/json/JavaJsonRequests.md

```
--- /Users/garbagetown/Desktop/2.1.5/manual/javaGuide/main/json/JavaJsonRequests.md 2013-09-19 22:53:02.000000000 +0900
+++ /Users/garbagetown/Desktop/2.2.0/manual/javaGuide/main/json/JavaJsonRequests.md 2013-09-19 10:11:22.000000000 +0900
@@ -7,7 +7,7 @@
 By default an action uses an **any content** body parser, which you can use to retrieve the body as JSON (actually as a Jackson `JsonNode`):

 '''java
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 ...

 public static Result sayHello() {
@@ -28,7 +28,7 @@
 Of course it’s way better (and simpler) to specify our own `BodyParser` to ask Play to parse the content body directly as JSON:

 '''java
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import play.mvc.BodyParser;
 ...

@@ -72,7 +72,7 @@

 '''java
 import play.libs.Json;
-import org.codehaus.jackson.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
 ...

 @BodyParser.Of(BodyParser.Json.class)
@@ -102,4 +102,4 @@
 {"status":"OK","message":"Hello Guillaume"}
 '''

-> **Next:** [[Working with XML | JavaXmlRequests]]
\ No newline at end of file
+> **Next:** [[Working with XML | JavaXmlRequests]]

```
