### PR TITLE
manual/javaGuide/main/templates/JavaTemplateUseCases.md

### DIFF
--- a/documentation/2.2.0/manual/javaGuide/main/templates/JavaTemplateUseCases.md
+++ b/documentation/2.2.0/manual/javaGuide/main/templates/JavaTemplateUseCases.md
@@ -1,10 +1,23 @@
+<!-- translated -->
+<!--
 # Common template use cases
+-->
+# テンプレートのよくある使い方
 
+<!--
 Templates, being simple functions, can be composed in any way you want. Below are a few examples of some common scenarios.
+-->
+テンプレートは単純な関数なので、いかようにも組み合わせることができます。このページでは、よくある利用シナリオを紹介していきます。
 
+<!--
 ## Layout
+-->
+## レイアウト
 
+<!--
 Let’s declare a `views/main.scala.html` template that will act as a main layout template:
+-->
+メインレイアウトとして機能する `views/main.scala.html` というテンプレートを定義してみましょう。
 
 ```html
 @(title: String)(content: Html)
@@ -20,7 +33,10 @@ Let’s declare a `views/main.scala.html` template that will act as a main layou
 
 ```
 
+<!--
 As you can see, this template takes two parameters: a title and an HTML content block. Now we can use it from another `views/Application/index.scala.html` template:
+-->
+ご覧のとおり、このテンプレートはタイトルと HTML コンテンツを含むブロックの二つの引数を取ります。このテンプレートは、例えば `views/Application/index.scala.html` のような別のテンプレートから、次のように利用することができます。
 
 ```html
 @main(title = "Home") {
@@ -30,9 +46,15 @@ As you can see, this template takes two parameters: a title and an HTML content 
 }
 ```
 
+<!--
 > **Note:** You can use both named parameters (like `@main(title = "Home")` and positional parameters, like `@main("Home")`. Choose whichever is clearer in a specific context.
+-->
+> **Note:** `@main("Home")` の代わりに、名前付き引数を使って `@main(title = "Home")` のように書くこともあります。時と場合に応じてテンプレートが読みやすくなる方を選ぶとよいでしょう。
 
+<!--
 Sometimes you need a second page-specific content block for a sidebar or breadcrumb trail, for example. You can do this with an additional parameter:
+-->
+例えば、ページのメインコンテンツ以外にサイドバーやパンくずなどに副次的な内容を埋め込みたい場合、次のようにパラメータを追加するとよいでしょう。
 
 ```html
 @(title: String)(sidebar: Html)(content: Html)
@@ -48,7 +70,10 @@ Sometimes you need a second page-specific content block for a sidebar or breadcr
 </html>
 ```
 
+<!--
 Using this from our ‘index’ template, we have:
+-->
+これを先ほどの `index` テンプレートから、以下のように利用することができます。
 
 ```html
 @main("Home") {
@@ -60,7 +85,10 @@ Using this from our ‘index’ template, we have:
 }
 ```
 
+<!--
 Alternatively, we can declare the sidebar block separately:
+-->
+別の書き方として、サイドバー向けのブロックをレイアウトの呼び出しとは全く別に宣言することもできます。
 
 ```html
 @sidebar = {
@@ -74,9 +102,15 @@ Alternatively, we can declare the sidebar block separately:
 ```
 
 
+<!--
 ## Tags (they are just functions right?)
+-->
+## タグ
 
+<!--
 Let’s write a simple `views/tags/notice.scala.html` tag that displays an HTML notice:
+-->
+Web ページ上に通知を表示するための単純なタグ `views/tags/notice.scala.html` を書いてみましょう。
 
 ```html
 @(level: String = "error")(body: (String) => Html)
@@ -104,7 +138,10 @@ Let’s write a simple `views/tags/notice.scala.html` tag that displays an HTML 
 }
 ```
 
+<!--
 And now let’s use it from another template:
+-->
+このタグを別のテンプレートから呼び出すには、次のように書きます。
 
 ```html
 @import tags._
@@ -114,9 +151,15 @@ And now let’s use it from another template:
 }
 ```
 
+<!--
 ## Includes
+-->
+## インクルード
 
+<!--
 Again, there’s nothing special here. You can just call any other template you like (or in fact any other function, wherever it is defined):
+-->
+これも、特別なことは何もありません。次のように、他のテンプレートを単に呼び出すだけで OK です (実際には、テンプレートに限らず、関数であればなんでも呼び出せます) 。
 
 ```html
 <h1>Home</h1>
@@ -126,9 +169,15 @@ Again, there’s nothing special here. You can just call any other template you 
 </div>
 ```
 
+<!--
 ## moreScripts and moreStyles equivalents
+-->
+## moreScripts と moreStyles 相当の変数
 > **Next:** [[HTTP form submission and validation | ScalaForms]]
+<!--
 To define old moreScripts or moreStyles variables equivalents (like on Play! 1.x) on a Scala template, you can define a variable in the main template like this :
+-->
+Scala テンプレートにおいて (Play! 1.x のような) 古い moreScripts または moreStyles 相当の変数を定義するために、メインテンプレートにて以下のような変数を定義することができます :
 
 ```html
 @(title: String, scripts: Html = Html(""))(content: Html)
@@ -158,7 +207,10 @@ To define old moreScripts or moreStyles variables equivalents (like on Play! 1.x
 </html>
 ```
 
+<!--
 And on an extended template that need an extra script : 
+-->
+そして、追加のスクリプトが必要な拡張テンプレートでは、以下のようにします :
 
 ```html
 @scripts = {
@@ -173,7 +225,10 @@ And on an extended template that need an extra script :
 
 ```
 
+<!--
 And on an extended template that not need an extra script, just like this :
+-->
+そして、追加のスクリプトを必要としない拡張テンプレートでは、単に以下のようにします :
 
 ```html
 @main("Title"){

--- a/documentation/2.2.0/manual/javaGuide/main/templates/JavaTemplateUseCases.md
+++ b/documentation/2.2.0/manual/javaGuide/main/templates/JavaTemplateUseCases.md
@@ -173,10 +173,11 @@ Again, there’s nothing special here. You can just call any other template you 
 ## moreScripts and moreStyles equivalents
 -->
 ## moreScripts と moreStyles 相当の変数
-> **Next:** [[HTTP form submission and validation | ScalaForms]]
 <!--
+> **Next:** [[HTTP form submission and validation | ScalaForms]]
 To define old moreScripts or moreStyles variables equivalents (like on Play! 1.x) on a Scala template, you can define a variable in the main template like this :
 -->
+> **Next:** [[HTTP フォームの投稿とバリデーション | ScalaForms]]
 Scala テンプレートにおいて (Play! 1.x のような) 古い moreScripts または moreStyles 相当の変数を定義するために、メインテンプレートにて以下のような変数を定義することができます :
 
 ```html
@@ -238,4 +239,7 @@ And on an extended template that not need an extra script, just like this :
 }
 ```
 
+<!--
 > **Next:** [[Custom formats | JavaCustomTemplateFormat]]
+-->
+> **次ページ:** [[カスタムフォーマット | JavaCustomTemplateFormat]]


### PR DESCRIPTION
- https://github.com/garbagetown/playdocja/blob/2.2.0/documentation/2.2.0/manual/javaGuide/main/templates/JavaTemplateUseCases.md

```
--- /Users/garbagetown/Desktop/2.1.5/manual/javaGuide/main/templates/JavaTemplateUseCases.md    2013-09-19 22:53:02.000000000 +0900
+++ /Users/garbagetown/Desktop/2.2.0/manual/javaGuide/main/templates/JavaTemplateUseCases.md    2013-09-19 10:11:22.000000000 +0900
@@ -127,7 +127,7 @@
 '''

 ## moreScripts and moreStyles equivalents
-
+> **Next:** [[HTTP form submission and validation | ScalaForms]]
 To define old moreScripts or moreStyles variables equivalents (like on Play! 1.x) on a Scala template, you can define a variable in the main template like this :

 '''html
@@ -183,4 +183,4 @@
 }
 '''

-> **Next:** [[HTTP form submission and validation | JavaForms]]
\ No newline at end of file
+> **Next:** [[Custom formats | JavaCustomTemplateFormat]]
\ No newline at end of file

```
