### PR TITLE
manual/javaGuide/main/xml/JavaXmlRequests.md

### DIFF
--- a/documentation/2.2.0/manual/javaGuide/main/xml/JavaXmlRequests.md
+++ b/documentation/2.2.0/manual/javaGuide/main/xml/JavaXmlRequests.md
@@ -1,10 +1,20 @@
+<!-- translated -->
+<!--
 # Handling and serving XML requests
+-->
+# XML リクエストとレスポンス
 
+<!--
 ## Handling an XML request
+-->
+## XML リクエストの処理
 
 An XML request is an HTTP request using a valid XML payload as request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.
 
+<!--
 By default, an action uses an **any content** body parser, which you can use to retrieve the body as XML (actually as a `org.w3c.Document`):
+-->
+アクションは **any content** ボディパーサーをデフォルトで使います。これを利用して、リクエストボディを XML (具体的には `org.w3c.Document`) として取得することができます。
 
 ```
 public static Result sayHello() {
@@ -22,7 +32,10 @@ public static Result sayHello() {
 }
 ```
 
+<!--
 Of course it’s way better (and simpler) to specify our own `BodyParser` to ask Play to parse the content body directly as XML:
+-->
+この場合、専用の`BodyParser` を指定することで Play にコンテントボディを直接的に XML としてパースさせると、記述がシンプル化されてなお良いでしょう。
 
 ```
 @BodyParser.Of(Xml.class)
@@ -41,9 +54,15 @@ public static Result sayHello() {
 }
 ```
 
+<!--
 > **Note:** This way, a 400 HTTP response will be automatically returned for non-XML requests.
+-->
+> **ノート:** この方法では、XML 以外のリクエストに対しては自動的に HTTP の 400 番のレスポンスが返ってきます。
 
+<!--
 You can test it with **cURL** on the command line:
+-->
+このアクションは、コマンドラインから **cURL** を使って以下のようにテストできます。
 
 ```
 curl 
@@ -53,7 +72,10 @@ curl
   http://localhost:9000/sayHello
 ```
 
+<!--
 It replies with:
+-->
+レスポンスは以下のようになります。
 
 ```
 HTTP/1.1 200 OK
@@ -63,9 +85,15 @@ Content-Length: 15
 Hello Guillaume
 ```
 
+<!--
 ## Serving an XML response
+-->
+## XML レスポンスの送信
 
+<!--
 In our previous example, we handled an XML request, but replied with a `text/plain` response. Let’s change it to send back a valid XML HTTP response:
+-->
+前述の例では XML リクエストを処理して、`text/plain` のレスポンスを返してしまっていました。これを、正しい XML HTTP レスポンスを送り返すように変更してみましょう。
 
 ```
 @BodyParser.Of(Xml.class)
@@ -84,7 +112,10 @@ public static Result sayHello() {
 }
 ```
 
+<!--
 Now it replies with:
+-->
+レスポンスは以下のようになります。
 
 ```
 HTTP/1.1 200 OK
@@ -94,4 +125,7 @@ Content-Length: 46
 <message status="OK">Hello Guillaume</message>
 ```
 
+<!--
 > **Next:** [[Handling file upload | JavaFileUpload]]
+-->
+> **次ページ:** [[ファイルアップロードの処理 | JavaFileUpload]]

--- a/documentation/2.2.0/manual/javaGuide/main/xml/JavaXmlRequests.md
+++ b/documentation/2.2.0/manual/javaGuide/main/xml/JavaXmlRequests.md
@@ -9,7 +9,10 @@
 -->
 ## XML リクエストの処理
 
+<!--
 An XML request is an HTTP request using a valid XML payload as request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.
+-->
+XML リクエストはリクエストボディに XML データを含む HTTP リクエストです。XML リクエストの `Content-Type` ヘッダには、 `application/xml` もしくは `text/xml` という MIME タイプを指定する必要があります。
 
 <!--
 By default, an action uses an **any content** body parser, which you can use to retrieve the body as XML (actually as a `org.w3c.Document`):


### PR DESCRIPTION
- https://github.com/garbagetown/playdocja/blob/2.2.0/documentation/2.2.0/manual/javaGuide/main/xml/JavaXmlRequests.md

```
--- /Users/garbagetown/Desktop/2.1.5/manual/javaGuide/main/xml/JavaXmlRequests.md   2013-09-19 22:53:02.000000000 +0900
+++ /Users/garbagetown/Desktop/2.2.0/manual/javaGuide/main/xml/JavaXmlRequests.md   2013-09-19 10:11:22.000000000 +0900
@@ -2,7 +2,7 @@

 ## Handling an XML request

-An XML request is an HTTP request using a valid XML payload as request body. It must specify the `text/xml` MIME type in its `Content-Type` header.
+An XML request is an HTTP request using a valid XML payload as request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.

 By default, an action uses an **any content** body parser, which you can use to retrieve the body as XML (actually as a `org.w3c.Document`):

@@ -47,7 +47,7 @@

 '''
 curl 
-  --header "Content-type: text/xml" 
+  --header "Content-type: application/xml" 
   --request POST 
   --data '<name>Guillaume</name>' 
   http://localhost:9000/sayHello
@@ -88,10 +88,10 @@

 '''
 HTTP/1.1 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Length: 46

 <message status="OK">Hello Guillaume</message>
 '''

-> **Next:** [[Handling file upload | JavaFileUpload]]
\ No newline at end of file
+> **Next:** [[Handling file upload | JavaFileUpload]]

```
