### PR TITLE
manual/scalaGuide/main/sql/ScalaDatabaseOthers.md

### DIFF
--- a/documentation/2.2.0/manual/scalaGuide/main/sql/ScalaDatabaseOthers.md
+++ b/documentation/2.2.0/manual/scalaGuide/main/sql/ScalaDatabaseOthers.md
@@ -14,7 +14,10 @@ Play の `play.api.db.DB` ヘルパーを使って `Connection` や `Datasource`
 -->
 ## ScalaQuery の利用
 
+<!--
 From here you can integrate any JDBC access layer that needs a JDBC data source. For example, to integrate with [ScalaQuery](https://github.com/szeiger/scala-query):
+-->
+JDBC データソースを必要とする JDBC アクセスレイヤーを利用する方法を説明します。例えば、[ScalaQuery](https://github.com/szeiger/scala-query) を利用する場合は次のように書きます。
 
 ```scala
 import play.api.db._

--- a/documentation/2.2.0/manual/scalaGuide/main/sql/ScalaDatabaseOthers.md
+++ b/documentation/2.2.0/manual/scalaGuide/main/sql/ScalaDatabaseOthers.md
@@ -1,8 +1,18 @@
+<!-- translated -->
+<!--
 # Integrating with other database libraries
+-->
+# データベースライブラリの利用
 
+<!--
 You can use any **SQL** database access library you like with Play, and easily retrieve either a `Connection` or a `Datasource` from the `play.api.db.DB` helper.
+-->
+Play の `play.api.db.DB` ヘルパーを使って `Connection` や `Datasource` を取得すると、あらゆる **SQL** データベースアクセスライブラリを利用することができます。
 
+<!--
 ## Integrating with ScalaQuery
+-->
+## ScalaQuery の利用
 
 From here you can integrate any JDBC access layer that needs a JDBC data source. For example, to integrate with [ScalaQuery](https://github.com/szeiger/scala-query):
 
@@ -35,9 +45,15 @@ object Task extends Table[(Long, String, Date, Boolean)]("tasks") {
 }
 ```
 
+<!--
 ## Exposing the datasource through JNDI
+-->
+## JNDI を経由してデータソースを公開する
 
+<!--
 Some libraries expect to retrieve the `Datasource` reference from JNDI. You can expose any Play managed datasource via JNDI by adding this configuration in `conf/application.conf`:
+-->
+いくつかのライブラリは `Datasource` を JNDI 経由で取得します。そのような場合、`conf/application.conf` に設定を追記して、 Play が管理しているデータソースを JNDI 経由で公開するとよいでしょう。
 
 ```
 db.default.driver=org.h2.Driver
@@ -45,4 +61,7 @@ db.default.url="jdbc:h2:mem:play"
 db.default.jndiName=DefaultDS
 ```
 
+<!--
 > **Next:** [[Using the Cache | ScalaCache]]
+-->
+> **次ページ:** [[キャッシュ | ScalaCache]]


### PR DESCRIPTION
- https://github.com/garbagetown/playdocja/blob/2.2.0/documentation/2.2.0/manual/scalaGuide/main/sql/ScalaDatabaseOthers.md

```
--- /Users/garbagetown/Desktop/2.1.5/manual/scalaGuide/main/sql/ScalaDatabaseOthers.md  2013-09-19 22:53:02.000000000 +0900
+++ /Users/garbagetown/Desktop/2.2.0/manual/scalaGuide/main/sql/ScalaDatabaseOthers.md  2013-09-19 10:11:22.000000000 +0900
@@ -4,7 +4,7 @@

 ## Integrating with ScalaQuery

-From here you can integrate any JDBC access layer that needs a JDBC data source. For example, to integrate with [[ScalaQuery | https://github.com/szeiger/scala-query]]:
+From here you can integrate any JDBC access layer that needs a JDBC data source. For example, to integrate with [ScalaQuery](https://github.com/szeiger/scala-query):

 '''scala
 import play.api.db._
@@ -45,4 +45,4 @@
 db.default.jndiName=DefaultDS
 '''

-> **Next:** [[Using the Cache | ScalaCache]]
\ No newline at end of file
+> **Next:** [[Using the Cache | ScalaCache]]

```
