### PR TITLE
manual/scalaGuide/main/xml/ScalaXmlRequests.md

### DIFF
--- a/documentation/2.2.0/manual/scalaGuide/main/xml/ScalaXmlRequests.md
+++ b/documentation/2.2.0/manual/scalaGuide/main/xml/ScalaXmlRequests.md
@@ -9,7 +9,10 @@
 -->
 ## XML リクエストの処理
 
+<!--
 An XML request is an HTTP request using a valid XML payload as the request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.
+-->
+XML リクエストはリクエストボディに XML データを含む HTTP リクエストです。XML リクエストの `Content-Type` ヘッダには、`application/xml` もしくは `text/xml` という MIME タイプを指定する必要があります。
 
 <!--
 By default an `Action` uses a **any content** body parser, which lets you retrieve the body as XML (actually as a `NodeSeq`):

--- a/documentation/2.2.0/manual/scalaGuide/main/xml/ScalaXmlRequests.md
+++ b/documentation/2.2.0/manual/scalaGuide/main/xml/ScalaXmlRequests.md
@@ -1,20 +1,39 @@
+<!-- translated -->
+<!--
 # Handling and serving XML requests
+-->
+# XML リクエストとレスポンス
 
+<!--
 ## Handling an XML request
+-->
+## XML リクエストの処理
 
 An XML request is an HTTP request using a valid XML payload as the request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.
 
+<!--
 By default an `Action` uses a **any content** body parser, which lets you retrieve the body as XML (actually as a `NodeSeq`):
+-->
+`Action` は **any content** ボディパーサーをデフォルトで使います。これを利用して、リクエストボディを XML (具体的には `NodeSeq`) として取得することができます。
 
 @[xml-request-body-asXml](code/ScalaXmlRequests.scala)
 
+<!--
 It’s way better (and simpler) to specify our own `BodyParser` to ask Play to parse the content body directly as XML:
+-->
+この場合、専用の`BodyParser` を指定することで Play にコンテントボディを直接的に XML としてパースさせると、記述がシンプル化されてなお良いでしょう。
 
 @[xml-request-body-parser](code/ScalaXmlRequests.scala)
 
+<!--
 > **Note:** When using an XML body parser, the `request.body` value is directly a valid `NodeSeq`. 
+-->
+> **Note:** XML ボディパーサーを利用するときには、`request.body` の値が直接 `NodeSeq` になります。
 
+<!--
 You can test it with **cURL** from a command line:
+-->
+このアクションは、コマンドラインから **cURL** を使って以下のようにテストできます。
 
 ```
 curl 
@@ -24,7 +43,10 @@ curl
   http://localhost:9000/sayHello
 ```
 
+<!--
 It replies with:
+-->
+レスポンスは以下のようになります。
 
 ```
 HTTP/1.1 200 OK
@@ -34,13 +56,22 @@ Content-Length: 15
 Hello Guillaume
 ```
 
+<!--
 ## Serving an XML response
+-->
+## XML レスポンスの送信
 
+<!--
 In our previous example we handle an XML request, but we reply with a `text/plain` response. Let’s change that to send back a valid XML HTTP response:
+-->
+前述の例では XML リクエストを処理して、`text/plain` のレスポンスを返してしまっていました。これを、正しい XML HTTP レスポンスを送り返すように変更してみましょう。
 
 @[xml-request-body-parser-xml-response](code/ScalaXmlRequests.scala)
 
+<!--
 Now it replies with:
+-->
+レスポンスは以下のようになります。
 
 ```
 HTTP/1.1 200 OK
@@ -50,4 +81,7 @@ Content-Length: 46
 <message status="OK">Hello Guillaume</message>
 ```
 
+<!--
 > **Next:** [[Handling file upload | ScalaFileUpload]]
+-->
+> **次ページ:** [[ファイルアップロードの処理 | ScalaFileUpload]]


### PR DESCRIPTION
- https://github.com/garbagetown/playdocja/blob/2.2.0/documentation/2.2.0/manual/scalaGuide/main/xml/ScalaXmlRequests.md

```
--- /Users/garbagetown/Desktop/2.1.5/manual/scalaGuide/main/xml/ScalaXmlRequests.md 2013-09-19 22:53:02.000000000 +0900
+++ /Users/garbagetown/Desktop/2.2.0/manual/scalaGuide/main/xml/ScalaXmlRequests.md 2013-09-19 10:11:22.000000000 +0900
@@ -2,35 +2,15 @@

 ## Handling an XML request

-An XML request is an HTTP request using a valid XML payload as the request body. It must specify the `text/xml` MIME type in its `Content-Type` header.
+An XML request is an HTTP request using a valid XML payload as the request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.

 By default an `Action` uses a **any content** body parser, which lets you retrieve the body as XML (actually as a `NodeSeq`):

-'''scala
-def sayHello = Action { request =>
-  request.body.asXml.map { xml =>
-    (xml \\ "name" headOption).map(_.text).map { name =>
-      Ok("Hello " + name)
-    }.getOrElse {
-      BadRequest("Missing parameter [name]")
-    }
-  }.getOrElse {
-    BadRequest("Expecting Xml data")
-  }
-}
-'''
+@[xml-request-body-asXml](code/ScalaXmlRequests.scala)

 It’s way better (and simpler) to specify our own `BodyParser` to ask Play to parse the content body directly as XML:

-'''scala
-def sayHello = Action(parse.xml) { request =>
-  (request.body \\ "name" headOption).map(_.text).map { name =>
-    Ok("Hello " + name)
-  }.getOrElse {
-    BadRequest("Missing parameter [name]")
-  }
-}
-'''
+@[xml-request-body-parser](code/ScalaXmlRequests.scala)

 > **Note:** When using an XML body parser, the `request.body` value is directly a valid `NodeSeq`. 

@@ -38,7 +18,7 @@

 '''
 curl 
-  --header "Content-type: text/xml" 
+  --header "Content-type: application/xml" 
   --request POST 
   --data '<name>Guillaume</name>' 
   http://localhost:9000/sayHello
@@ -58,24 +38,16 @@

 In our previous example we handle an XML request, but we reply with a `text/plain` response. Let’s change that to send back a valid XML HTTP response:

-'''scala
-def sayHello = Action(parse.xml) { request =>
-  (request.body \\ "name" headOption).map(_.text).map { name =>
-    Ok(<message status="OK">Hello {name}</message>)
-  }.getOrElse {
-    BadRequest(<message status="KO">Missing parameter [name]</message>)
-  }
-}
-'''
+@[xml-request-body-parser-xml-response](code/ScalaXmlRequests.scala)

 Now it replies with:

 '''
 HTTP/1.1 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Length: 46

 <message status="OK">Hello Guillaume</message>
 '''

-> **Next:** [[Handling file upload | ScalaFileUpload]]
\ No newline at end of file
+> **Next:** [[Handling file upload | ScalaFileUpload]]

```
