### PR TITLE
Json の Format の variance に関する記述の細かい修正

### DIFF
--- a/documentation/2.1.5/manual/scalaGuide/main/json/ScalaJsonCombinators.md
+++ b/documentation/2.1.5/manual/scalaGuide/main/json/ScalaJsonCombinators.md
@@ -1893,7 +1893,7 @@ assert(Json.fromJson[Creature](zombiejs).get == zombie2)
 
 <!-- `Format[A]` is both covariant and contravariant (invariant) functor.
 So you must give both functions `A => B` and `B => A` to transform into a `Format[B]`. -->
-`Format[A]` は共変でもあり、反変 (不変) でもある要素です。
+`Format[A]` は共変でもあり反変でもある (つまり不変な) Functor です。
 このため、`Format[B]` に変換するための関数 `A => B` と関数 `B => A` の両方を与えてやらなければなりません。
 
 <!-- For example: -->


### PR DESCRIPTION
修正前の文だと "反変" と "不変" が同じ言葉の言い換えのように感じたが、
"共変かつ反変" だと "不変" ということなので、
細かい違いだが、こうなっていたほうがよいと思った。
また、"要素"という言葉を入れるのに違和感があったので、
Functorというのをそのまま残した
