### PR TITLE
translate the sidebar of WS SSL documentation #891

### DIFF
--- a/manual/detailedTopics/configuration/ws/_Sidebar.md
+++ b/manual/detailedTopics/configuration/ws/_Sidebar.md
@@ -1,6 +1,10 @@
 <!--- Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com> -->
+<!--
 ### Configuring WS SSL
+-->
+### WS SSL の設定
 
+<!--
 - [[Configuring WS SSL|WsSSL]]
 - [[Quick Start to WS SSL|WSQuickStart]]
 - [[Generating X.509 Certificates|CertificateGeneration]]
@@ -15,51 +19,129 @@
 - [[Debugging SSL|DebuggingSSL]]
 - [[Loose Options|LooseSSL]]
 - [[Testing SSL|TestingSSL]]
+-->
+- [[WS SSL の設定|WsSSL]]
+- [[WS SSL クイックスタート|WSQuickStart]]
+- [[X.509 証明書の生成|CertificateGeneration]]
+- [[トラストストアとキーストアの設定|KeyStores]]
+- [[プロトコルの設定|Protocols]]
+- [[Cipher Suites の設定|CipherSuites]]
+- [[Certificate Validation の設定|CertificateValidation]]
+- [[証明書失効の設定|CertificateRevocation]]
+- [[ホスト名検証の設定|HostnameVerification]]
+- [[設定の例|ExampleSSLConfig]]
+- [[デフォルトの SSLContext の使用|DefaultContext]]
+- [[SSL のデバッグ|DebuggingSSL]]
+- [[緩いオプション|LooseSSL]]
+- [[SSL のテスト|TestingSSL]]
 
+<!--
 ### Getting started
+-->
+### はじめに
 
+<!--
 - [[Installing Play | Installing]]
 - [[Creating a new application | NewApplication]]
 - [[Anatomy of a Play application | Anatomy]]
 - [[Using the Play console | PlayConsole ]]
 - [[Setting-up your preferred IDE | IDE]]
 - [[Play Tutorials|Tutorials]]
+-->
+- [[Play のインストール | Installing]]
+- [[新規アプリケーションを作成する | NewApplication]]
+- [[Play アプリケーションの構造 | Anatomy]]
+- [[Play コンソールを使う | PlayConsole]]
+- [[好きな IDE で開発する | IDE]]
+- [[Play チュートリアル|Tutorials]]
 
+<!--
 ### Working with Play
+-->
+### Play で開発する
+
+<!--
 - [[Play for Scala developers | ScalaHome]]
 - [[Play for Java developers | JavaHome]]
+-->
+- [[Scala 開発者のための Play | ScalaHome]]
+- [[Java 開発者のための Play | JavaHome]]
 
+<!--
 ### Detailed topics
+-->
+### 詳細なトピック
 
+<!--
 - [[The Build system | Build]]
 - [[Working with public assets | Assets]]
 - [[Managing database evolutions | Evolutions]]
 - [[Configuration | Configuration]]
 - [[Deploying your application | Production]]
+-->
+- [[ビルドシステム | Build]]
+- [[公開アセットを使う | Assets]]
+- [[データベース進化の管理 | Evolutions]]
+- [[設定 | Configuration]]
+- [[アプリケーションのデプロイ | Production]]
 
+<!--
 ### Additional documentations
+-->
+### その他のドキュメント
 
+<!--
+- [Scala](http://docs.scala-lang.org/)
+- [Akka](http://akka.io/docs/)
+- [sbt](http://www.scala-sbt.org/learn.html)
+- [Configuration](https://github.com/typesafehub/config)
+- [Logback](http://logback.qos.ch/documentation.html)
+-->
 - [Scala](http://docs.scala-lang.org/)
 - [Akka](http://akka.io/docs/)
 - [sbt](http://www.scala-sbt.org/learn.html)
 - [Configuration](https://github.com/typesafehub/config)
 - [Logback](http://logback.qos.ch/documentation.html)
 
+<!--
 ### Hacking Play
+-->
+### Play を Hack する
 
+<!--
 - [[Building Play from source|BuildingFromSource]]
 - [[3rd Party Tools|ThirdPartyTools]]
 - [[Repositories|Repositories]]
 - [[Issue tracker|Issues]]
 - [[Contributor guidelines|Guidelines]]
 - [[Documentation guidelines|Documentation]]
+-->
+- [[ソースから Play をビルドする|BuildingFromSource]]
+- [[サードパーティツール|ThirdPartyTools]]
+- [[リポジトリ|Repositories]]
+- [[課題トラッカ|Issues]]
+- [[貢献者ガイドライン|Guidelines]]
+- [[ドキュメントガイドライン|Documentation]]
 
+<!--
 ### About Play
+-->
+### Play について
 
+<!--
 - [[Play Philosophy|Philosophy]]
 - [[Play User Groups|PlayUserGroups]]
+-->
+- [[Play の哲学|Philosophy]]
+- [[Play ユーザーグループ|PlayUserGroups]]
 
+<!--
 ### Modules and plugins
+-->
+### モジュールとプラグイン
 
+<!--
 - [[Temporary modules directory|Modules]]
+-->
+- [[一時的なモジュールディレクトリ|Modules]]
 


### PR DESCRIPTION
新規のサイドバー部分を翻訳+反映しました。 #891

SSL 周りの用語はどの程度翻訳するのかが難しかったのですが、Google 先生の検索結果で見比べた結果、 Cipher Suites (暗号群)および Certificate Validation (証明書確認)以外は Oracle のドキュメントに引っかかったので翻訳しました。
